### PR TITLE
Implement Redis migration dry run

### DIFF
--- a/redis/README.md
+++ b/redis/README.md
@@ -30,3 +30,18 @@ For example:
 ```shell
 python3 pymigration.py database.composedb.com mypassword123 99999 redis.test.databases.appdomain.cloud mypassword456 88888  ~/path/to/cert --sslsrc --ssldst
 ```
+
+## Dry run
+
+To test your migration, add the `--dryrun` flag. This is helpful for confirming connectivity, existing keys, etc.
+without triggering the actual migration.
+
+For example:
+
+```shell
+python3 redis_migration.py --dryrun ...
+```
+
+If destination flushing (`--flush`) is enabled in combination with `--dryrun`, the script will act as if the
+destination were flushed without actually flushing it. The reported amount of already existing keys will always
+be zero.

--- a/redis/README.md
+++ b/redis/README.md
@@ -22,13 +22,13 @@ These can be gathered using the `ibmcloud cdb` command.
 Once you've got the credentials to your IBM Cloud Databases for Redis database, you can run the script using Python 3 from the terminal.
 
 ```shell
-python3 pymigration.py <source host> <source password> <source port> <destination host> <destination password> <destination port>  <destination ca certificate path> --sslsrc --ssldst
+python3 redis_migration.py <source host> <source password> <source port> <destination host> <destination password> <destination port>  <destination ca certificate path> --sslsrc --ssldst
 ```
 
 For example:
 
 ```shell
-python3 pymigration.py database.composedb.com mypassword123 99999 redis.test.databases.appdomain.cloud mypassword456 88888  ~/path/to/cert --sslsrc --ssldst
+python3 redis_migration.py database.composedb.com mypassword123 99999 redis.test.databases.appdomain.cloud mypassword456 88888  ~/path/to/cert --sslsrc --ssldst
 ```
 
 ## Dry run


### PR DESCRIPTION
## What?

This implements a dry run mode for the Redis migration script.

## Why?

This is helpful for confirming connectivity, existing keys, etc. without actually executing the migration, or flushing the destination database.

## How?

The new flag is `--dryrun`.

When paired with `--flush`, the destination is not flushed, though the migration script pretends as if it were; in other words, the `already_existing` count will always be zero in the case.