### PR TITLE
Allow username for source database

### DIFF
--- a/redis/redis_migration.py
+++ b/redis/redis_migration.py
@@ -44,7 +44,11 @@ def migrate(srchost, srchostauth, srchostport, dsthost, dsthostauth, dsthostport
         print('Source and destination must be different.')
         return
 
-    source = redis.Redis(host=srchost, port=int(srchostport), db=db, password=srchostauth, ssl=sslsrc, ssl_cert_reqs=None)
+    if ":" in srchostauth:
+      username, password = srchostauth.split(":")
+      source = redis.Redis(host=srchost, port=int(srchostport), db=db, username=username, password=password, ssl=sslsrc, ssl_cert_reqs=None)
+    else:
+      source = redis.Redis(host=srchost, port=int(srchostport), db=db, password=srchostauth, ssl=sslsrc, ssl_cert_reqs=None)
 
     if ":" in dsthostauth:
       username, password = dsthostauth.split(":")


### PR DESCRIPTION
Allow a username for the source database to be passed in as well as a password.- to support source databases that enable ACL